### PR TITLE
added streamline interception to suppress HDR UI alpha and HUD-less color inputs from DLSSG

### DIFF
--- a/src/games/007firstlight/addon.cpp
+++ b/src/games/007firstlight/addon.cpp
@@ -16,6 +16,7 @@
 #include "../../mods/shader.hpp"
 #include "../../utils/date.hpp"
 #include "../../utils/settings.hpp"
+#include "dlss.hpp"
 #include "isfast_noise.hpp"
 #include "shared.h"
 
@@ -252,6 +253,16 @@ renodx::utils::settings::Settings settings = {
         .labels = {"Off", "Sharp", "Filtered"},
     },
     new renodx::utils::settings::Setting{
+        .key = "DLSSGHUDGhostingFix",
+        .binding = &firstlight::dlss::dlssg_hud_ghosting_fix,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .label = "DLSS FG HUD Ghosting Fix",
+        .section = "DLSS Frame Generation",
+        .tooltip = "Hides the game's HDR UI alpha and HUD-less color inputs from DLSS Frame Generation to reduce HUD ghosting and disocclusion artifacts.",
+        .labels = {"Off", "On"},
+    },
+    new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::BUTTON,
         .label = "Reset All",
         .section = "Options",
@@ -364,6 +375,7 @@ void OnPresetOff() {
       {"FxGrainStrength", 50.f},
       {"FxISFASTShadows", 0.f},
       {"FxSSRReflectionFix", 0.f},
+      {"DLSSGHUDGhostingFix", 1.f},
   });
 }
 
@@ -403,12 +415,14 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);  // detect peak nits
       reshade::register_event<reshade::addon_event::init_device>(firstlight::isfast::OnInitDevice);
       reshade::register_event<reshade::addon_event::destroy_device>(firstlight::isfast::OnDestroyDevice);
+      firstlight::dlss::Use(fdw_reason);
 
       break;
     case DLL_PROCESS_DETACH:
       reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);  // detect peak nits
       reshade::unregister_event<reshade::addon_event::init_device>(firstlight::isfast::OnInitDevice);
       reshade::unregister_event<reshade::addon_event::destroy_device>(firstlight::isfast::OnDestroyDevice);
+      firstlight::dlss::Use(fdw_reason);
 
       reshade::unregister_addon(h_module);
       break;

--- a/src/games/007firstlight/dlss.hpp
+++ b/src/games/007firstlight/dlss.hpp
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <sstream>
+#include <tuple>
+#include <vector>
+
+#include "../../utils/dlss/streamline_v2.hpp"
+#include "../../utils/log.hpp"
+#include "../../utils/vtable.hpp"
+
+namespace firstlight::dlss {
+
+inline float dlssg_hud_ghosting_fix = 1.f;
+inline bool logged_dlssg_override = false;
+inline bool attached = false;
+inline bool hook_installed = false;
+inline bool logged_waiting_for_streamline = false;
+inline bool logged_ui_tag_suppression = false;
+
+inline sl::Result (*Real_slSetTag)(
+    const sl::ViewportHandle& viewport,
+    const sl::ResourceTag* tags,
+    uint32_t numTags,
+    sl::CommandBuffer* cmdBuffer) = nullptr;
+
+inline decltype(&slSetTagForFrame) Real_slSetTagForFrame = nullptr;
+
+inline bool ShouldSuppressResourceTag(sl::BufferType type) {
+  if (dlssg_hud_ghosting_fix == 0.f) return false;
+  if (type == sl::kBufferTypeUIColorAndAlpha) return true;
+  if (type == sl::kBufferTypeHUDLessColor) return true;
+  return false;
+}
+
+inline uint32_t CountSuppressedTags(const sl::ResourceTag* tags, uint32_t numTags) {
+  if (tags == nullptr) return 0u;
+
+  uint32_t suppressed_count = 0u;
+  for (uint32_t i = 0u; i < numTags; ++i) {
+    if (ShouldSuppressResourceTag(tags[i].type)) {
+      ++suppressed_count;
+    }
+  }
+  return suppressed_count;
+}
+
+inline void LogSuppressedUITag(uint32_t suppressed_count) {
+  if (logged_ui_tag_suppression || suppressed_count == 0u) return;
+  logged_ui_tag_suppression = true;
+
+  std::stringstream s;
+  s << "007 DLSSG: suppressing " << suppressed_count
+    << " UI/HUD Streamline tag(s) to avoid HDR FG HUD ghosting.";
+  reshade::log::message(reshade::log::level::info, s.str().c_str());
+}
+
+inline std::vector<sl::ResourceTag> BuildFilteredTags(const sl::ResourceTag* tags, uint32_t numTags, uint32_t suppressed_count) {
+  std::vector<sl::ResourceTag> filtered_tags;
+  filtered_tags.reserve(numTags - suppressed_count);
+
+  for (uint32_t i = 0u; i < numTags; ++i) {
+    if (ShouldSuppressResourceTag(tags[i].type)) continue;
+    filtered_tags.push_back(tags[i]);
+  }
+
+  return filtered_tags;
+}
+
+inline sl::Result HookedSlSetTag(
+    const sl::ViewportHandle& viewport,
+    const sl::ResourceTag* tags,
+    uint32_t numTags,
+    sl::CommandBuffer* cmdBuffer) {
+  const auto suppressed_count = CountSuppressedTags(tags, numTags);
+  if (suppressed_count == 0u) {
+    return Real_slSetTag(viewport, tags, numTags, cmdBuffer);
+  }
+
+  LogSuppressedUITag(suppressed_count);
+  auto filtered_tags = BuildFilteredTags(tags, numTags, suppressed_count);
+  if (filtered_tags.empty()) return sl::Result::eOk;
+
+  return Real_slSetTag(viewport, filtered_tags.data(), static_cast<uint32_t>(filtered_tags.size()), cmdBuffer);
+}
+
+inline sl::Result HookedSlSetTagForFrame(
+    const sl::FrameToken& frame,
+    const sl::ViewportHandle& viewport,
+    const sl::ResourceTag* tags,
+    uint32_t numTags,
+    sl::CommandBuffer* cmdBuffer) {
+  const auto suppressed_count = CountSuppressedTags(tags, numTags);
+  if (suppressed_count == 0u) {
+    return Real_slSetTagForFrame(frame, viewport, tags, numTags, cmdBuffer);
+  }
+
+  LogSuppressedUITag(suppressed_count);
+  auto filtered_tags = BuildFilteredTags(tags, numTags, suppressed_count);
+  if (filtered_tags.empty()) return sl::Result::eOk;
+
+  return Real_slSetTagForFrame(frame, viewport, filtered_tags.data(), static_cast<uint32_t>(filtered_tags.size()), cmdBuffer);
+}
+
+inline const std::vector<renodx::utils::vtable::HookItem> kStreamlineDLSSGOptionsHooks = {
+    {"slSetTag",
+     reinterpret_cast<void**>(&Real_slSetTag),
+     reinterpret_cast<void*>(&HookedSlSetTag)},
+    {"slSetTagForFrame",
+     reinterpret_cast<void**>(&Real_slSetTagForFrame),
+     reinterpret_cast<void*>(&HookedSlSetTagForFrame)},
+    {"slGetFeatureFunction",
+     reinterpret_cast<void**>(&renodx::utils::streamline::v2::Real_slGetFeatureFunction),
+     reinterpret_cast<void*>(&renodx::utils::streamline::v2::Hooked_slGetFeatureFunction)},
+};
+
+inline void OverrideDLSSGSetOptions(const sl::ViewportHandle& viewport, sl::DLSSGOptions& options) {
+  (void)viewport;
+
+  if (dlssg_hud_ghosting_fix != 0.f) {
+    // The game's HDR UI separation buffers cause DLSS Frame Generation to create UI/object
+    // ghosts. Hide them from Streamline and let FG operate on the final backbuffer instead.
+    options.uiBufferFormat = 0u;
+    options.hudLessBufferFormat = 0u;
+    options.flags &= ~sl::DLSSGFlags::eEnableFullscreenMenuDetection;
+  }
+
+  if (!logged_dlssg_override) {
+    logged_dlssg_override = true;
+    std::stringstream s;
+    s << "007 DLSSG: HUD ghosting fix " << (dlssg_hud_ghosting_fix != 0.f ? "enabled" : "disabled")
+      << ", uiBufferFormat=" << options.uiBufferFormat
+      << ", hudLessBufferFormat=" << options.hudLessBufferFormat
+      << ", flags=0x" << std::hex << static_cast<uint32_t>(options.flags);
+    reshade::log::message(reshade::log::level::info, s.str().c_str());
+  }
+}
+
+inline void TryInstallStreamlineHook() {
+  if (hook_installed) return;
+
+  auto* sl_interposer = GetModuleHandleA("sl.interposer.dll");
+  if (sl_interposer == nullptr) {
+    if (!logged_waiting_for_streamline) {
+      logged_waiting_for_streamline = true;
+      renodx::utils::log::w("007 DLSSG: sl.interposer.dll is not loaded yet; UI alpha fix hook will retry later.");
+    }
+    return;
+  }
+
+  if (renodx::utils::vtable::Hook(sl_interposer, kStreamlineDLSSGOptionsHooks)) {
+    hook_installed = true;
+    renodx::utils::log::i("007 DLSSG: Streamline slDLSSGSetOptions hook installed.");
+  } else {
+    renodx::utils::log::w("007 DLSSG: Streamline hook was not installed.");
+  }
+}
+
+inline void OnInitDevice(reshade::api::device* device) {
+  (void)device;
+  TryInstallStreamlineHook();
+}
+
+inline void Use(DWORD fdw_reason) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (attached) return;
+      attached = true;
+      renodx::utils::streamline::v2::override_dlssg_set_options = &OverrideDLSSGSetOptions;
+      reshade::register_event<reshade::addon_event::init_device>(OnInitDevice);
+      TryInstallStreamlineHook();
+      break;
+    case DLL_PROCESS_DETACH:
+      if (!attached) return;
+      attached = false;
+      reshade::unregister_event<reshade::addon_event::init_device>(OnInitDevice);
+      renodx::utils::streamline::v2::override_dlssg_set_options = nullptr;
+      hook_installed = false;
+      logged_waiting_for_streamline = false;
+      logged_dlssg_override = false;
+      logged_ui_tag_suppression = false;
+      break;
+    default:
+      break;
+  }
+}
+
+}  // namespace firstlight::dlss


### PR DESCRIPTION
Hi Musa, I added a streamline interception to suppress HDR UI alpha and HUDless color inputs from DLSSG. It resolves most of the issues with ghosting and warping when using FG and HDR. I tried to keep it clean by adding a separate dlss.hpp.